### PR TITLE
Hack attempting to greedy regex match (return longest text instead of shorter)

### DIFF
--- a/examples/long_match.py
+++ b/examples/long_match.py
@@ -1,0 +1,142 @@
+import time
+
+import torch
+from dotenv import load_dotenv
+
+import outlines
+
+# prompt: set variable 'my_device' to the available cuda
+
+
+def t1(model):
+    prompt = """You are a sentiment-labelling assistant.
+    Is the following review positive or negative?
+
+    Review: This restaurant is just awesome!
+    """
+
+    generator = outlines.generate.choice(model, ["Positive", "Negative"])
+    answer = generator(prompt)
+    print(answer)
+
+
+def t2(model):
+    prompt = "<s>result of 9 + 9 = 18</s><s>result of 1 + 2 = "
+    answer = outlines.generate.format(model, int)(prompt)
+    print(answer)
+
+
+def t3(model):
+    prompt = "sqrt(2)="
+    generator = outlines.generate.format(model, float)
+    answer = generator(prompt, max_tokens=10)
+    print(answer)
+
+
+def t4u(model):
+    prompt = "What is the IP address of the Google DNS servers? "
+
+    start_time = time.time()
+
+    generator = outlines.generate.text(model)
+    unstructured = generator(prompt, max_tokens=30)
+
+    execution_time = time.time() - start_time
+
+    # What is the IP address of the Google DNS servers?
+    #
+    # Passive DNS servers are at DNS servers that are private.
+    # In other words, both IP servers are private. The database
+    # does not contain Chelsea Manning
+
+    print(unstructured)
+    print(f"Execution time: {execution_time} seconds")
+
+
+def t4s(model):
+    prompt = "What is the IP address of the Google DNS servers? "
+
+    start_time = time.time()
+
+    pattern = r"((25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(25[0-5]|2[0-4]\d|[01]?\d\d?)"
+    generator = outlines.generate.regex(
+        model,
+        pattern,
+    )
+    structured = generator(prompt, max_tokens=30)
+
+    execution_time = time.time() - start_time
+    print(structured)
+    # What is the IP address of the Google DNS servers?
+    # 2.2.6.1
+
+    print(f"Execution time {pattern}: {execution_time} seconds")
+
+
+def t5(model):
+    prompt = "What is the IP address of the Google DNS servers? "
+    start_time = time.time()
+
+    pattern = r"((\d){1,3}\.){3}(\d){1,3}"
+
+    generator = outlines.generate.regex(
+        model,
+        pattern,
+    )
+    structured = generator(prompt, max_tokens=30)
+
+    execution_time = time.time() - start_time
+    print(structured)
+    # What is the IP address of the Google DNS servers?
+    # 2.2.6.1
+
+    print(f"Execution time {pattern}: {execution_time} seconds")
+
+
+def t6(model):
+    prompt = "What is the IP address of the Google DNS servers? "
+    start_time = time.time()
+
+    pattern = r"((\d){1,3}\.)+(\d){1,3}"
+    generator = outlines.generate.regex(
+        model,
+        pattern,
+    )
+    structured = generator(prompt, max_tokens=30)
+
+    execution_time = time.time() - start_time
+    print(structured)
+    # What is the IP address of the Google DNS servers?
+    # 2.2.6.1
+
+    print(f"Execution time {pattern}: {execution_time} seconds")
+
+
+if __name__ == "__main__":
+    load_dotenv()
+    my_device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"Using device: {my_device}")
+    print()
+
+    # model_name = "hf-internal-testing/tiny-random-GPTJForCausalLM"
+    model_name = "TinyLlama/TinyLlama-1.1B-Chat-v0.6"
+
+    # might be better
+    model = outlines.models.transformers(model_name, device=my_device)
+
+    t1(model)
+    print()
+    t2(model)
+    print()
+    try:
+        t3(model)  # Sometimes fail because result is not float
+    except ValueError:
+        pass
+    print()
+    t4u(model)
+    print()
+    t4s(model)
+    print()
+    t5(model)
+    print()
+    t6(model)

--- a/outlines/generate/cfg.py
+++ b/outlines/generate/cfg.py
@@ -4,7 +4,8 @@ from outlines.fsm.guide import CFGGuide
 from outlines.generate.api import SequenceGenerator, SequenceGeneratorAdapter
 from outlines.models import OpenAI
 from outlines.models.llamacpp import LlamaCpp
-from outlines.models.vllm import VLLM
+
+# from outlines.models.vllm import VLLM
 from outlines.samplers import Sampler, multinomial
 
 
@@ -33,15 +34,15 @@ def cfg(model, cfg_str: str, sampler: Sampler = multinomial()) -> SequenceGenera
     return generator
 
 
-@cfg.register(VLLM)
-def cfg_vllm(
-    model: VLLM,
-    cfg_str: str,
-    sampler: Sampler = multinomial(),
-):
-    raise NotImplementedError(
-        "The CFG Logits processor is not available for the vLLM integration."
-    )
+# @cfg.register(VLLM)
+# def cfg_vllm(
+#     model: VLLM,
+#     cfg_str: str,
+#     sampler: Sampler = multinomial(),
+# ):
+#     raise NotImplementedError(
+#         "The CFG Logits processor is not available for the vLLM integration."
+#     )
 
 
 @cfg.register(LlamaCpp)

--- a/outlines/generate/regex.py
+++ b/outlines/generate/regex.py
@@ -4,7 +4,8 @@ from outlines.fsm.guide import RegexGuide
 from outlines.generate.api import SequenceGenerator, SequenceGeneratorAdapter
 from outlines.models import OpenAI
 from outlines.models.llamacpp import LlamaCpp
-from outlines.models.vllm import VLLM
+
+# from outlines.models.vllm import VLLM
 from outlines.samplers import Sampler, multinomial
 
 
@@ -49,16 +50,16 @@ def regex_llamacpp(
     return SequenceGeneratorAdapter(model, logits_processor, sampler)
 
 
-@regex.register(VLLM)
-def regex_vllm(
-    model: VLLM,
-    regex_str: str,
-    sampler: Sampler = multinomial(),
-):
-    from outlines.integrations.vllm import RegexLogitsProcessor
+# @regex.register(VLLM)
+# def regex_vllm(
+#     model: VLLM,
+#     regex_str: str,
+#     sampler: Sampler = multinomial(),
+# ):
+#     from outlines.integrations.vllm import RegexLogitsProcessor
 
-    logits_processor = RegexLogitsProcessor(regex_str, model.model)
-    return SequenceGeneratorAdapter(model, logits_processor, sampler)
+#     logits_processor = RegexLogitsProcessor(regex_str, model.model)
+#     return SequenceGeneratorAdapter(model, logits_processor, sampler)
 
 
 @regex.register(OpenAI)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ test = [
     "llama-cpp-python",
     "huggingface_hub",
     "openai>=1.0.0",
-    "vllm",
+    # "vllm",
     "torch",
     "transformers",
 ]

--- a/tests/generate/test_integration_vllm.py
+++ b/tests/generate/test_integration_vllm.py
@@ -3,13 +3,17 @@ import re
 
 import pytest
 import torch
-from pydantic import BaseModel, constr
-from vllm.sampling_params import SamplingParams
 
 import outlines.generate as generate
 import outlines.grammars as grammars
 import outlines.models as models
 import outlines.samplers as samplers
+
+# from pydantic import BaseModel, constr
+
+
+# from vllm.sampling_params import SamplingParams
+
 
 pytestmark = pytest.mark.skipif(
     not torch.cuda.is_available(), reason="vLLM models can only be run on GPU."
@@ -52,19 +56,19 @@ def test_vllm_generation_api(model, generator_type, params):
     assert len(res) == 2
 
 
-def test_vllm_sampling_params(model):
-    generator = generate.text(model)
+# def test_vllm_sampling_params(model):
+#     generator = generate.text(model)
 
-    sampling_params = SamplingParams(n=2)
-    res = generator("test", sampling_params=sampling_params)
-    assert len(res) == 2
-    assert isinstance(res[0], str)
-    assert isinstance(res[1], str)
+#     sampling_params = SamplingParams(n=2)
+#     res = generator("test", sampling_params=sampling_params)
+#     assert len(res) == 2
+#     assert isinstance(res[0], str)
+#     assert isinstance(res[1], str)
 
-    sampling_params = SamplingParams(seed=2)
-    res1 = generator("test", sampling_params=sampling_params)
-    res2 = generator("test", sampling_params=sampling_params)
-    assert res1 == res2
+#     sampling_params = SamplingParams(seed=2)
+#     res1 = generator("test", sampling_params=sampling_params)
+#     res2 = generator("test", sampling_params=sampling_params)
+#     assert res1 == res2
 
 
 def test_vllm_greedy_sampling(model):
@@ -190,44 +194,44 @@ def test_vllm_choice(model):
     assert sequence == "test" or sequence == "choice"
 
 
-def test_vllm_json_basic(model):
-    prompt = "Output some JSON. "
+# def test_vllm_json_basic(model):
+#     prompt = "Output some JSON. "
 
-    class Spam(BaseModel):
-        spam: constr(max_length=10)
-        fuzz: bool
+#     class Spam(BaseModel):
+#         spam: constr(max_length=10)
+#         fuzz: bool
 
-    sampling_params = SamplingParams(temperature=0)
-    result = generate.json(model, Spam, whitespace_pattern="")(
-        prompt, max_tokens=100, seed=1, sampling_params=sampling_params
-    )
-    assert isinstance(result, BaseModel)
-    assert isinstance(result.spam, str)
-    assert isinstance(result.fuzz, bool)
-    assert len(result.spam) <= 10
+#     sampling_params = SamplingParams(temperature=0)
+#     result = generate.json(model, Spam, whitespace_pattern="")(
+#         prompt, max_tokens=100, seed=1, sampling_params=sampling_params
+#     )
+#     assert isinstance(result, BaseModel)
+#     assert isinstance(result.spam, str)
+#     assert isinstance(result.fuzz, bool)
+#     assert len(result.spam) <= 10
 
 
-def test_vllm_json_schema(model):
-    prompt = "Output some JSON. "
+# def test_vllm_json_schema(model):
+#     prompt = "Output some JSON. "
 
-    schema = """{
-      "title": "spam",
-      "type": "object",
-      "properties": {
-           "foo" : {"type": "boolean"},
-           "bar": {"type": "string", "maxLength": 4}
-        },
-      "required": ["foo", "bar"]
-      }
-    """
+#     schema = """{
+#       "title": "spam",
+#       "type": "object",
+#       "properties": {
+#            "foo" : {"type": "boolean"},
+#            "bar": {"type": "string", "maxLength": 4}
+#         },
+#       "required": ["foo", "bar"]
+#       }
+#     """
 
-    sampling_params = SamplingParams(temperature=0)
-    result = generate.json(model, schema, whitespace_pattern="")(
-        prompt, max_tokens=100, seed=10, sampling_params=sampling_params
-    )
-    assert isinstance(result, dict)
-    assert isinstance(result["foo"], bool)
-    assert isinstance(result["bar"], str)
+#     sampling_params = SamplingParams(temperature=0)
+#     result = generate.json(model, schema, whitespace_pattern="")(
+#         prompt, max_tokens=100, seed=10, sampling_params=sampling_params
+#     )
+#     assert isinstance(result, dict)
+#     assert isinstance(result["foo"], bool)
+#     assert isinstance(result["bar"], str)
 
 
 @pytest.mark.xfail(


### PR DESCRIPTION
The motivation was to be able to write a simpler regex for extracting the IP address using this prompt taken from the documentation:
```
"What is the IP address of the Google DNS servers? "
```
What if we want to say _1-3 digits, separated by \._?
For instance, using this regex: `((\d){1,3}\.)+(\d){1,3}`.

## Hack

The current implementation produces a _lazy match_, extracting the shortest possible text. The idea would be to produce a _greedy match_.

In the code, a generation is considered finished when the FSM state is final for a single regex. The hack is to replace that by considering a state when it has no successors. That should be correct in a reduced FSM.

Below, I'd like to discuss why this is intrinsically broken.

## Changes

The small hack can be tested using' examples/long_match.py,` which contains examples based on the initial regex in the documentation. 

The PR has these commits:
1. Disable vllm because I don't have a GPU
2. Hack in `outlines/generate/generator.py:is_generation_finished().`
3. Test byte_level FSM for a string in test failing reported below

## Pytest

All tests are passing except this one that was expecting a float.
```
FAILED tests/generate/test_integration_transformers.py::test_transformers_integration_float
ValueError: could not convert string to float: '34E.2e46200'
```

The regex for the type `float` is:
```
INTEGER = r"[+-]?(0|[1-9][0-9]*)"
FLOAT = rf"{INTEGER}(\.[0-9]+)?([eE][+-][0-9]+)?"
```
The string '34E.2e46200' is not accepted by that regex as it has two `e`, so **there is a bug**.

## Testing the hack

For testing on my laptop, without GPU, I used this small model: `TinyLlama/TinyLlama-1.1B-Chat-v0.6`.

The script `examples/long_match.py` reports results in this format:
```
<output>
Execution time {regex if used}: {rtime} seconds

```

Without the commits of this branch, `examples/long_match.py` prints:
```
...
3. What is the port number of the IPHONE application server? 4. What is the port number of the Crosswalk client application server
Execution time: 16.58834671974182 seconds

2.3.2.2
Execution time ((25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(25[0-5]|2[0-4]\d|[01]?\d\d?): 3.303622007369995 seconds

4.2.3.3
Execution time ((\d){1,3}\.){3}(\d){1,3}: 3.149822950363159 seconds

5.2
Execution time ((\d){1,3}\.)+(\d){1,3}: 1.1710660457611084 seconds
```

The motivation was to get a longer match for the last regex. Let's see the result of the hack.
In this branch, the script produces the following output.
```
...
2. Can you provide me with instructions on how to connect VLC Player to Microsoft Edge? 3. Can you list the output playback possibilities
Execution time: 14.899611234664917 seconds

2.2.10.11817948342731907317018
Execution time ((25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(25[0-5]|2[0-4]\d|[01]?\d\d?): 15.943550109863281 seconds

7.4.4.359386129748593513
Execution time ((\d){1,3}\.){3}(\d){1,3}: 12.276262998580933 seconds

4.4.2.2.2.2.3.6.2.1.14.12.3.1.
Execution time ((\d){1,3}\.)+(\d){1,3}: 14.84356689453125 seconds
```

For `((\d){1,3}\.)+(\d){1,3}`, other runs returned:
```
125.193.248.127
7.2.7.3.1.1.2.4.1.8.9.10.11.12
```

## Observations

- Largest running times are expected
- The implementation masks out the transitions with tokens not accepted by the FSM. However, their score could be low.
- That might be less of an issue when using lazy match.
- In greedy match, a FSM could continue matching as far as there are some possible continuations, not matter their likelihood.

## Improvements

- For a single FSM, this hack for a naive lazy-match, would commit in the beam to expand any path that might end up producing another string. If some required token has likelihood zero, then a path that went through a final state might might be lost.
- In general, LLM decoding with constraints is multi-objective: on the one hand, we want high likelihood; on the other, we want to satisfy the constraint.
- For beam search, we could solve this by 
  - Adding to the beam paths with final states while adding them for expansion if there are successors.
  - Discarding paths with low normalized score, that is divided by the length (as introduced for NLT).

## The bug

The string '34E.2e46200' should not be returned. However, this new test uses that string with FLOAT and is passing:
```
tests/fsm/test_regex.py::test_byte_level_regex
```

Perhaps the hack needs to be corrected or more fragile.